### PR TITLE
feat(chat): add desktop execute tool for DeepAgents

### DIFF
--- a/backend/agent_server/graph.py
+++ b/backend/agent_server/graph.py
@@ -171,6 +171,12 @@ def _runtime_cache_key(
         "deepagents_write_file_max_chars": int(
             getattr(settings, "deepagents_write_file_max_chars", 50000) or 50000
         ),
+        "desktop_plugin_execute_enabled": bool(
+            getattr(settings, "desktop_plugin_execute_enabled", False)
+        ),
+        "desktop_plugin_execute_timeout_seconds": float(
+            getattr(settings, "desktop_plugin_execute_timeout_seconds", 20.0) or 20.0
+        ),
         "deepagents_extra_skills_dir": str(
             getattr(settings, "deepagents_extra_skills_dir", "") or ""
         ),

--- a/backend/app/services/deepagents/deepagents_graph.py
+++ b/backend/app/services/deepagents/deepagents_graph.py
@@ -37,6 +37,7 @@ from app.services.deepagents.input_mapping import build_chat_messages
 from app.services.deepagents.output_utils import extract_answer
 from app.services.tools.tool_helpers import _result_error
 from app.services.tools.tools_device import tool_device, tool_screen_get
+from app.services.tools.tools_execute import tool_execute
 from app.services.tools.tools_files import tool_attachment_search
 from app.services.tools.tools_gws import tool_google_workspace
 from app.services.tools.tools_web import tool_web_search
@@ -155,6 +156,18 @@ class GoogleWorkspaceToolInput(BaseModel):
     docs_content: str | None = None
 
 
+class ExecuteToolInput(BaseModel):
+    command: str = Field(..., description="Non-interactive shell command to execute.")
+    cwd: str | None = Field(
+        default=None,
+        description="Optional working directory inside the allowed local workspace roots.",
+    )
+    timeout_ms: int | None = Field(
+        default=None,
+        description="Optional timeout in milliseconds (1000-120000).",
+    )
+
+
 def _build_deepagents_http_timeout(service: LLMService) -> httpx.Timeout:
     request_timeout = max(5.0, float(getattr(service, "timeout_seconds", 90.0) or 90.0))
     read_timeout = max(
@@ -266,6 +279,13 @@ def _tool_description(name: str) -> str:
         return (
             "Capture a desktop screenshot for visual inspection.\n"
             "Only use when visual evidence is required. Avoid repeated screenshots with the same arguments."
+        )
+    if name == "execute":
+        return (
+            "Execute a non-interactive shell command on the local desktop runtime.\n"
+            "Arguments: command=<non-empty string>, cwd?<allowed directory>, timeout_ms=1000..120000.\n"
+            "Use for coding or inspection tasks like running tests, listing files, or checking git status.\n"
+            "Avoid interactive commands, long-running dev servers, or commands that wait for user input."
         )
     return name
 
@@ -765,6 +785,15 @@ def build_chat_tools(
         _make_device_tool(),
         _make_screen_get_tool(),
     ]
+    if bool(getattr(settings, "desktop_plugin_execute_enabled", False)):
+        tools.append(
+            _make_structured_tool(
+                "execute",
+                tool_execute,
+                ExecuteToolInput,
+                ["command", "cwd", "timeout_ms"],
+            )
+        )
     return tools, tool_runs, usage
 
 
@@ -811,6 +840,7 @@ def build_chat_agent(
         "- google_workspace: choose a concrete action and include all required fields before calling; never blindly retry writes.\n"
         "- device: only use status/open_url/open_aelin when the user explicitly asks for desktop or browser navigation; open_url requires a valid http(s) URL.\n"
         "- screen_get: capture only when visual evidence is necessary; avoid repeated screenshots with the same arguments.\n"
+        "- execute: use only for short, non-interactive local commands; always provide a concrete command; avoid shells, dev servers, or commands that may wait for user input.\n"
         f"{_current_date_context()}\n"
         "If the user asks about date-sensitive facts, keep the answer explicitly grounded to the current date context above.\n"
         "If search results contain stale dates, say that clearly instead of silently treating them as current.\n"

--- a/backend/app/services/deepagents/tool_runtime.py
+++ b/backend/app/services/deepagents/tool_runtime.py
@@ -249,6 +249,17 @@ def build_tool_signature(name: str, args: dict[str, Any]) -> str:
             ensure_ascii=False,
             sort_keys=True,
         )
+    if tool == "execute":
+        return json.dumps(
+            {
+                "tool": tool,
+                "command": _normalize_text((args or {}).get("command")),
+                "cwd": _normalize_text((args or {}).get("cwd")),
+                "timeout_ms": int((args or {}).get("timeout_ms") or 0),
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
     return json.dumps({"tool": tool, "args": args or {}}, ensure_ascii=False, sort_keys=True)
 
 
@@ -259,6 +270,7 @@ def _tool_attempt_limit(name: str) -> int:
         "google_workspace": 4,
         "device": 2,
         "screen_get": 2,
+        "execute": 4,
     }.get(str(name or "").strip().lower(), 2)
 
 
@@ -322,6 +334,12 @@ def _invalid_reason(name: str, args: dict[str, Any]) -> str:
             return "invalid device call: action must be one of status, open_url, open_aelin"
         if action == "open_url" and not _normalize_url((args or {}).get("url")):
             return "invalid device call: open_url requires a non-empty http(s) url"
+    if tool == "execute":
+        command = str((args or {}).get("command") or "").strip()
+        if not command:
+            return "invalid execute call: provide a non-empty command"
+        if len(command) > 4000:
+            return "invalid execute call: command is too long"
     return ""
 
 
@@ -333,6 +351,8 @@ def classify_tool_call(name: str, args: dict[str, Any]) -> bool:
         return action in {"open_url", "open_aelin"}
     if tool in {"web_search", "attachment_search", "screen_get"}:
         return False
+    if tool == "execute":
+        return True
     if tool == "google_workspace":
         return action in {"calendar_create_event", "gmail_send", "gmail_draft", "docs_create"}
     return False
@@ -368,7 +388,7 @@ class ToolCallLimiter:
 
     def evaluate(self, *, name: str, args: dict[str, Any], usage: ToolPolicyUsage) -> ToolPolicyDecision:
         tool = str(name or "").strip().lower()
-        if tool not in {"device", "web_search", "attachment_search", "screen_get", "google_workspace"}:
+        if tool not in {"device", "web_search", "attachment_search", "screen_get", "google_workspace", "execute"}:
             return ToolPolicyDecision(allowed=False, is_write=False, reason="unsupported_tool")
 
         invalid_reason = _invalid_reason(tool, args)

--- a/backend/app/services/device/device_actions.py
+++ b/backend/app/services/device/device_actions.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 from app.services.device.device_center import (
     activate_desktop_module,
     capture_device_screen,
+    execute_desktop_command,
     DesktopPluginActionError,
     DeviceScreenCaptureError,
     open_desktop_external_url,
@@ -109,6 +110,53 @@ def screen_get_result(args: dict[str, Any]) -> dict[str, Any]:
         "source_display": str(shot.get("source_display") or "")[:64],
         "captured_at": str(shot.get("captured_at") or "")[:64],
     }
+
+
+def execute_command_result(args: dict[str, Any]) -> dict[str, Any]:
+    command = str(args.get("command") or "").strip()
+    if not command:
+        return {"ok": False, "error": "missing_command"}
+
+    cwd = str(args.get("cwd") or "").strip()
+    try:
+        timeout_ms = int(args.get("timeout_ms") or 0)
+    except Exception:
+        timeout_ms = 0
+
+    try:
+        result = execute_desktop_command(
+            command=command,
+            cwd=cwd,
+            timeout_ms=timeout_ms or None,
+        )
+    except DesktopPluginActionError as exc:
+        return {"ok": False, "error": exc.detail}
+    except Exception as exc:  # noqa: BLE001
+        return {"ok": False, "error": f"desktop_execute_failed:{str(exc)[:160]}"}
+
+    exit_code = result.get("exit_code")
+    timed_out = bool(result.get("timed_out"))
+    summary = str(result.get("summary") or "").strip()
+    ok = not timed_out and int(exit_code if exit_code is not None else 0) == 0
+    payload = {
+        "ok": ok,
+        "command": str(result.get("command") or command),
+        "cwd": str(result.get("cwd") or cwd),
+        "exit_code": exit_code,
+        "stdout": str(result.get("stdout") or ""),
+        "stderr": str(result.get("stderr") or ""),
+        "timed_out": timed_out,
+        "summary": summary or (
+            "command succeeded"
+            if ok
+            else ("command timed out" if timed_out else f"command failed with exit code {exit_code}")
+        ),
+    }
+    if timed_out:
+        payload["error"] = "command_timed_out"
+    elif not ok and exit_code is not None:
+        payload["error"] = f"command_exit_{exit_code}"
+    return payload
 
 
 def run_device_action(args: dict[str, Any]) -> dict[str, Any]:

--- a/backend/app/services/device/device_center.py
+++ b/backend/app/services/device/device_center.py
@@ -182,6 +182,78 @@ def activate_desktop_module(route: str = "/") -> dict[str, Any]:
     return _normalize_plugin_action_result(raw, primary_value=str(raw.get("route") or route_clean)[:120], primary_key="route")
 
 
+def _truncate_output(value: Any, limit: int) -> str:
+    text = str(value or "")
+    max_chars = max(256, int(limit or 0))
+    if len(text) <= max_chars:
+        return text
+    omitted = len(text) - max_chars
+    return f"{text[:max_chars]}\n...[truncated {omitted} chars]"
+
+
+def execute_desktop_command(
+    *,
+    command: str,
+    cwd: str = "",
+    timeout_ms: int | None = None,
+) -> dict[str, Any]:
+    if not bool(getattr(settings, "desktop_plugin_execute_enabled", False)):
+        raise DesktopPluginActionError(status_code=403, detail="desktop_execute_disabled")
+
+    command_clean = str(command or "").strip()
+    if not command_clean:
+        raise DesktopPluginActionError(status_code=400, detail="missing_command")
+
+    timeout_default_ms = int(
+        max(1.0, float(getattr(settings, "desktop_plugin_execute_timeout_seconds", 20.0) or 20.0))
+        * 1000
+    )
+    timeout_clean = max(1_000, min(120_000, int(timeout_ms or timeout_default_ms)))
+    output_limit = int(getattr(settings, "desktop_plugin_execute_max_output_chars", 12_000) or 12_000)
+    payload: dict[str, Any] = {
+        "command": command_clean,
+        "timeout_ms": timeout_clean,
+    }
+    cwd_clean = str(cwd or "").strip()
+    if cwd_clean:
+        payload["cwd"] = cwd_clean
+
+    raw = _desktop_plugin_post(
+        "/v1/desktop/command/execute",
+        payload,
+        timeout_s=max(
+            float(_desktop_plugin_config()["timeout_seconds"]),
+            (timeout_clean / 1000.0) + 3.0,
+        ),
+    )
+
+    try:
+        exit_code_raw = raw.get("exit_code")
+        exit_code = None if exit_code_raw is None else int(exit_code_raw)
+    except Exception:
+        exit_code = None
+
+    timed_out = bool(raw.get("timed_out"))
+    stdout = _truncate_output(raw.get("stdout"), output_limit)
+    stderr = _truncate_output(raw.get("stderr"), output_limit)
+    summary = str(raw.get("summary") or "").strip()[:200]
+    resolved_cwd = str(raw.get("cwd") or cwd_clean)[:1024]
+
+    return {
+        "command": command_clean,
+        "cwd": resolved_cwd,
+        "exit_code": exit_code,
+        "stdout": stdout,
+        "stderr": stderr,
+        "timed_out": timed_out,
+        "summary": summary or (
+            f"command exited with code {exit_code}"
+            if exit_code is not None
+            else ("command timed out" if timed_out else "command finished")
+        ),
+    }
+
+
 def _normalize_plugin_action_result(raw: dict[str, Any], *, primary_value: str, primary_key: str) -> dict[str, Any]:
     return {
         primary_key: primary_value,
@@ -198,10 +270,16 @@ def device_status_snapshot() -> dict[str, Any]:
         "desktop_plugin_configured": desktop_plugin_configured,
         "desktop_open_url": desktop_plugin_configured,
         "desktop_activate_module": desktop_plugin_configured,
+        "desktop_execute_command": (
+            desktop_plugin_configured
+            and bool(getattr(settings, "desktop_plugin_execute_enabled", False))
+        ),
     }
     notes: list[str] = []
     if not desktop_plugin_configured:
         notes.append("desktop plugin unconfigured: open_url / activate_module unavailable")
+    elif not bool(getattr(settings, "desktop_plugin_execute_enabled", False)):
+        notes.append("desktop command execution disabled")
     return {
         "platform": platform_name,
         "capabilities": capabilities,

--- a/backend/app/services/device/device_contract.py
+++ b/backend/app/services/device/device_contract.py
@@ -5,7 +5,7 @@ from typing import Any
 from app.services.device.device_center import device_status_snapshot
 
 
-SUPPORTED_DEEPAGENTS_TOOLS = [
+BASE_DEEPAGENTS_TOOLS = [
     "device",
     "screen_get",
 ]
@@ -15,6 +15,15 @@ SUPPORTED_DEVICE_ACTIONS = [
     "open_url",
     "open_aelin",
 ]
+
+
+def supported_deepagents_tools(snapshot: dict[str, Any] | None = None) -> list[str]:
+    state = snapshot or device_status_snapshot()
+    capabilities = dict(state.get("capabilities") or {})
+    tools = list(BASE_DEEPAGENTS_TOOLS)
+    if bool(capabilities.get("desktop_execute_command")):
+        tools.append("execute")
+    return tools
 
 
 def build_device_status_contract(snapshot: dict[str, Any] | None = None) -> dict[str, Any]:

--- a/backend/app/services/device/remote_control.py
+++ b/backend/app/services/device/remote_control.py
@@ -13,8 +13,8 @@ from app.models import User
 from app.schemas import ChatRequest, ChatResponse, RemoteControlExecuteRequest
 from app.services.device import device_actions
 from app.services.device.device_contract import (
-    SUPPORTED_DEEPAGENTS_TOOLS,
     SUPPORTED_DEVICE_ACTIONS,
+    supported_deepagents_tools,
 )
 from app.services.device.remote_control_chat_adapter import (
     is_deepagents_no_result_response,
@@ -96,7 +96,7 @@ def build_remote_control_status() -> dict[str, Any]:
         "source": "remote_control",
         "capabilities": dict(tool_status.get("capabilities") or {}),
         "notes": list(tool_status.get("notes") or []),
-        "supported_tools": list(SUPPORTED_DEEPAGENTS_TOOLS),
+        "supported_tools": supported_deepagents_tools(tool_status),
         "supported_device_actions": list(SUPPORTED_DEVICE_ACTIONS),
         "desktop_plugin_reachable": bool(tool_status.get("desktop_plugin_reachable")),
         "generated_at": datetime.now(timezone.utc),

--- a/backend/app/services/tools/tools_execute.py
+++ b/backend/app/services/tools/tools_execute.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.deepagents.tool_runtime import ToolRuntimeContext
+from app.services.device.device_actions import execute_command_result
+
+
+def tool_execute(_context: ToolRuntimeContext, args: dict[str, Any]) -> dict[str, Any]:
+    return execute_command_result(args)

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -134,6 +134,9 @@ class Settings(BaseSettings):
     desktop_plugin_token: str = ""
     desktop_plugin_timeout_seconds: float = 12.0
     desktop_plugin_capture_max_data_url_length: int = 3_000_000
+    desktop_plugin_execute_enabled: bool = False
+    desktop_plugin_execute_timeout_seconds: float = 20.0
+    desktop_plugin_execute_max_output_chars: int = 12_000
     # Google Workspace CLI (gws) integration.
     # `google_workspace_cli_bin` 可以是 "gws"（放在 PATH 中），也可以是一个绝对路径。
     google_workspace_cli_bin: str = "gws"

--- a/backend/tests/test_aelin_device.py
+++ b/backend/tests/test_aelin_device.py
@@ -19,6 +19,7 @@ def test_device_capabilities_endpoint_contract():
         "desktop_plugin_configured",
         "desktop_open_url",
         "desktop_activate_module",
+        "desktop_execute_command",
     ]:
         assert key in caps
 
@@ -200,5 +201,68 @@ def test_desktop_plugin_health_bypasses_proxy_env(monkeypatch):
     assert captured["trust_env"] is False
     assert captured["follow_redirects"] is False
     assert captured["url"] == "http://127.0.0.1:21914/healthz"
+
+
+def test_execute_desktop_command_proxy_success(monkeypatch):
+    monkeypatch.setattr(settings, "desktop_plugin_base_url", "http://127.0.0.1:21914")
+    monkeypatch.setattr(settings, "desktop_plugin_token", "plugin-token")
+    monkeypatch.setattr(settings, "desktop_plugin_execute_enabled", True)
+    monkeypatch.setattr(settings, "desktop_plugin_execute_timeout_seconds", 20.0)
+    monkeypatch.setattr(settings, "desktop_plugin_execute_max_output_chars", 120)
+
+    captured: dict[str, object] = {}
+
+    class _FakeResponse:
+        def __init__(self) -> None:
+            self.status_code = 200
+            self.text = ""
+
+        def json(self) -> dict[str, object]:
+            return {
+                "ok": True,
+                "cwd": "D:/Github/Aelin/backend",
+                "exit_code": 0,
+                "stdout": "ok",
+                "stderr": "",
+                "timed_out": False,
+                "summary": "command succeeded with exit code 0",
+            }
+
+    class _FakeClient:
+        def __init__(self, *args, **kwargs) -> None:
+            _ = args
+            captured["timeout"] = kwargs.get("timeout")
+
+        def __enter__(self) -> "_FakeClient":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            _ = exc_type, exc, tb
+            return None
+
+        def post(self, url: str, json: dict[str, object], headers: dict[str, str]):
+            captured["url"] = url
+            captured["json"] = json
+            captured["headers"] = headers
+            return _FakeResponse()
+
+    monkeypatch.setattr(device_center.httpx, "Client", _FakeClient)
+
+    result = device_center.execute_desktop_command(
+        command="pytest -q",
+        cwd="D:/Github/Aelin/backend",
+        timeout_ms=15_000,
+    )
+
+    assert captured["url"] == "http://127.0.0.1:21914/v1/desktop/command/execute"
+    assert captured["json"] == {
+        "command": "pytest -q",
+        "cwd": "D:/Github/Aelin/backend",
+        "timeout_ms": 15_000,
+    }
+    assert captured["headers"] == {"x-aelin-token": "plugin-token"}
+    assert float(captured["timeout"] or 0.0) >= 18.0
+    assert result["exit_code"] == 0
+    assert result["stdout"] == "ok"
 
 

--- a/backend/tests/test_aelin_tool_policy.py
+++ b/backend/tests/test_aelin_tool_policy.py
@@ -4,10 +4,11 @@ from app.services.deepagents.tool_runtime import ToolCallLimiter, ToolPolicyUsag
 
 
 def test_classify_write_tools():
-    # 仅 device / google_workspace 视为写操作，其余工具全部为只读。
+    # execute / device / google_workspace 视为写操作，其余工具全部为只读。
     assert classify_tool_call("device", {"action": "status"}) is False
     assert classify_tool_call("device", {"action": "open_url", "url": "https://example.com"}) is True
     assert classify_tool_call("device", {"action": "open_aelin", "route": "/"}) is True
+    assert classify_tool_call("execute", {"command": "pytest -q"}) is True
 
 
 def test_policy_allows_screen_get_when_reads_enabled():
@@ -47,6 +48,23 @@ def test_classify_device_actions():
     assert classify_tool_call("device", {"action": "status"}) is False
     assert classify_tool_call("device", {"action": "open_url", "url": "https://example.com"}) is True
     assert classify_tool_call("device", {"action": "open_aelin", "route": "/"}) is True
+    assert classify_tool_call("execute", {"command": "python -V"}) is True
+
+
+def test_policy_blocks_execute_when_writes_disabled():
+    policy = ToolCallLimiter(
+        max_tool_calls=4,
+        max_write_calls=1,
+        allow_write_tools=False,
+    )
+    decision = policy.evaluate(
+        name="execute",
+        args={"command": "pytest -q"},
+        usage=ToolPolicyUsage(total_calls=0, write_calls=0),
+    )
+    assert decision.allowed is False
+    assert decision.is_write is True
+    assert decision.reason == "write_tools_disabled"
 
 
 def test_google_workspace_policy_allows_reads_and_marks_writes():

--- a/backend/tests/test_aelin_tools.py
+++ b/backend/tests/test_aelin_tools.py
@@ -19,6 +19,7 @@ from app.services.deepagents.tool_runtime import (
 )
 from app.services.web.web_search import WebSearchResult
 from app.services.tools.tools_device import tool_device, tool_screen_get
+from app.services.tools.tools_execute import tool_execute
 from app.services.tools.tools_files import tool_attachment_search
 from app.services.tools.tools_gws import tool_google_workspace
 from app.services.tools.tools_web import tool_web_search
@@ -438,6 +439,34 @@ def test_device_tool_rejects_unknown_action():
     assert "unsupported device action" in str(result.get("error") or "")
 
 
+def test_execute_tool_returns_command_result(monkeypatch):
+    from app.services.tools import tools_execute
+
+    fake_web = _FakeWebSearch()
+    context = _tool_context(fake_web)
+
+    monkeypatch.setattr(
+        tools_execute,
+        "execute_command_result",
+        lambda args: {
+            "ok": True,
+            "command": str(args.get("command") or ""),
+            "cwd": str(args.get("cwd") or ""),
+            "exit_code": 0,
+            "stdout": "pytest passed",
+            "stderr": "",
+            "timed_out": False,
+            "summary": "command succeeded",
+        },
+    )
+
+    result = tool_execute(context, {"command": "pytest -q", "cwd": "D:/Github/Aelin/backend"})
+
+    assert result["ok"] is True
+    assert result["command"] == "pytest -q"
+    assert result["stdout"] == "pytest passed"
+
+
 def test_google_workspace_tool_runtime_and_auth_status(monkeypatch):
     from app.services.tools import tools_gws
 
@@ -630,6 +659,46 @@ def test_deepagents_build_chat_tools_uses_explicit_registered_tools(monkeypatch)
     assert calls
     assert calls[0]["args"] == {"action": "open_url", "url": "https://example.com"}
     assert any(tr["name"] == "device" and tr["status"] == "completed" for tr in tool_runs)
+
+
+def test_deepagents_build_chat_tools_registers_execute_when_enabled(monkeypatch):
+    from app.services.deepagents import deepagents_graph as dag
+
+    fake_web = _FakeWebSearch()
+    context = _tool_context(fake_web)
+    calls: list[dict[str, object]] = []
+
+    def _fake_tool_execute(tool_context, args):  # type: ignore[no-untyped-def]
+        calls.append({"tool_context": tool_context, "args": dict(args)})
+        return {
+            "ok": True,
+            "command": str(args.get("command") or ""),
+            "exit_code": 0,
+            "stdout": "ok",
+            "stderr": "",
+            "timed_out": False,
+            "summary": "command succeeded",
+        }
+
+    monkeypatch.setattr(dag, "tool_execute", _fake_tool_execute)
+    monkeypatch.setattr(dag.settings, "desktop_plugin_execute_enabled", True)
+
+    limiter = ToolCallLimiter(
+        max_tool_calls=20,
+        max_write_calls=10,
+        allow_write_tools=True,
+    )
+
+    tools, tool_runs, _usage = dag.build_chat_tools(context=context, limiter=limiter)
+
+    assert "execute" in [tool.name for tool in tools]
+    execute_tool = next(t for t in tools if t.name == "execute")
+    result = execute_tool.invoke({"command": "pytest -q", "cwd": "D:/Github/Aelin/backend"})
+
+    assert result["ok"] is True
+    assert calls
+    assert calls[0]["args"] == {"command": "pytest -q", "cwd": "D:/Github/Aelin/backend"}
+    assert any(tr["name"] == "execute" and tr["status"] == "completed" for tr in tool_runs)
 
 
 def test_deepagents_build_chat_tools_wraps_generic_tool_exceptions(monkeypatch):

--- a/backend/tests/test_remote_control.py
+++ b/backend/tests/test_remote_control.py
@@ -121,6 +121,31 @@ def test_remote_control_status_exposes_unified_device_contract(monkeypatch):
     ]
 
 
+def test_remote_control_status_includes_execute_when_capability_enabled(monkeypatch):
+    client = _create_test_client()
+    headers = _auth_headers(client)
+
+    monkeypatch.setattr(
+        remote_control.device_actions,
+        "device_status_result",
+        lambda: {
+            "ok": True,
+            "platform": "windows",
+            "capabilities": {
+                "desktop_open_url": True,
+                "desktop_execute_command": True,
+            },
+            "notes": [],
+            "desktop_plugin_reachable": True,
+        },
+    )
+
+    resp = client.get("/api/v1/aelin/remote-control/status", headers=headers)
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data.get("supported_tools") == ["device", "screen_get", "execute"]
+
+
 def test_feishu_bot_group_prefix_gate(monkeypatch):
     service = feishu_bot_module.FeishuBotService()
     sent_messages: list[tuple[str, str]] = []

--- a/desktop/src/aelin_desktop_runtime.cjs
+++ b/desktop/src/aelin_desktop_runtime.cjs
@@ -34,6 +34,11 @@ const APP_USER_MODEL_ID = "com.ttawdtt.aelin";
 const PET_DEBUG_LOG_ENABLED = process.env.AELIN_PET_DEBUG === "1";
 const PET_PLUGIN_API_ENABLED = process.env.AELIN_PET_PLUGIN_API_DISABLED !== "1";
 const PET_PLUGIN_API_TOKEN = String(process.env.AELIN_PET_PLUGIN_TOKEN || "").trim();
+const PET_PLUGIN_API_EXECUTE_ENABLED = process.env.AELIN_PET_PLUGIN_ALLOW_EXECUTE !== "0";
+const PET_PLUGIN_API_EXECUTE_MAX_OUTPUT_CHARS = Math.max(
+  1024,
+  Math.min(100000, Number(process.env.AELIN_PET_PLUGIN_EXECUTE_MAX_OUTPUT_CHARS || "12000"))
+);
 
 if (process.platform === "win32") {
   app.setAppUserModelId(APP_USER_MODEL_ID);
@@ -1017,6 +1022,24 @@ function createPetPluginApiApp() {
     }
   });
 
+  api.post("/v1/desktop/command/execute", async (req, res) => {
+    const body = req.body && typeof req.body === "object" ? req.body : {};
+    try {
+      const result = await executeLocalCommand(body);
+      res.json({
+        ok: true,
+        ...result,
+        ts: Date.now(),
+      });
+    } catch (error) {
+      const statusCode = Math.max(400, Math.min(503, Number(error?.statusCode || 500)));
+      res.status(statusCode).json({
+        ok: false,
+        detail: error instanceof Error ? error.message : String(error || "desktop_command_execute_failed"),
+      });
+    }
+  });
+
   api.get("/v1/pet/behavior", (_req, res) => {
     res.json({
       ok: true,
@@ -1152,6 +1175,115 @@ function frontendDir() {
 
 function frontendDistDir() {
   return app.isPackaged ? path.join(process.resourcesPath, "frontend-dist") : path.join(frontendDir(), "dist");
+}
+
+function createPluginHttpError(detail, statusCode = 400) {
+  const error = new Error(String(detail || "plugin_error"));
+  error.statusCode = Math.max(400, Math.min(503, Number(statusCode || 400)));
+  return error;
+}
+
+function safeRealpath(targetPath) {
+  const input = String(targetPath || "").trim();
+  if (!input) return "";
+  try {
+    return fs.realpathSync(input);
+  } catch {
+    return path.resolve(input);
+  }
+}
+
+function isPathWithinRoot(rootPath, targetPath) {
+  const root = safeRealpath(rootPath);
+  const target = safeRealpath(targetPath);
+  if (!root || !target) return false;
+  const relative = path.relative(root, target);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function buildAllowedExecuteRoots() {
+  const configured = String(process.env.AELIN_PET_PLUGIN_EXECUTE_ALLOWED_ROOTS || "")
+    .split(path.delimiter)
+    .map((item) => item.trim())
+    .filter(Boolean);
+  const defaults = [
+    projectRoot(),
+    backendDir(),
+    frontendDir(),
+    path.join(projectRoot(), "desktop"),
+  ];
+  const seen = new Set();
+  const roots = [];
+  for (const candidate of [...configured, ...defaults]) {
+    const resolved = safeRealpath(candidate);
+    if (!resolved || seen.has(resolved) || !fs.existsSync(resolved)) continue;
+    try {
+      if (!fs.statSync(resolved).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    seen.add(resolved);
+    roots.push(resolved);
+  }
+  return roots;
+}
+
+function resolveExecuteWorkingDirectory(raw) {
+  const fallback = safeRealpath(projectRoot());
+  const requested = String(raw || "").trim();
+  const candidate = requested
+    ? safeRealpath(path.isAbsolute(requested) ? requested : path.resolve(projectRoot(), requested))
+    : fallback;
+  if (!candidate || !fs.existsSync(candidate)) {
+    throw createPluginHttpError("cwd_not_found", 400);
+  }
+  try {
+    if (!fs.statSync(candidate).isDirectory()) {
+      throw createPluginHttpError("cwd_not_directory", 400);
+    }
+  } catch (error) {
+    if (error instanceof Error && "statusCode" in error) throw error;
+    throw createPluginHttpError("cwd_not_directory", 400);
+  }
+  const allowedRoots = buildAllowedExecuteRoots();
+  if (!allowedRoots.some((root) => isPathWithinRoot(root, candidate))) {
+    throw createPluginHttpError("cwd_not_allowed", 403);
+  }
+  return candidate;
+}
+
+function truncateExecuteOutput(raw) {
+  const text = String(raw || "");
+  if (text.length <= PET_PLUGIN_API_EXECUTE_MAX_OUTPUT_CHARS) return text;
+  const omitted = text.length - PET_PLUGIN_API_EXECUTE_MAX_OUTPUT_CHARS;
+  return `${text.slice(0, PET_PLUGIN_API_EXECUTE_MAX_OUTPUT_CHARS)}\n...[truncated ${omitted} chars]`;
+}
+
+function normalizeExecuteTimeoutMs(raw) {
+  const parsed = Number(raw);
+  const fallback = getProbeCommandTimeoutMs();
+  const base = Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  return Math.max(1000, Math.min(120000, Math.round(base)));
+}
+
+function buildExecuteLaunch(commandText) {
+  const command = String(commandText || "").trim();
+  if (!command) {
+    throw createPluginHttpError("missing_command", 400);
+  }
+  if (command.length > 4000) {
+    throw createPluginHttpError("command_too_long", 400);
+  }
+  if (process.platform === "win32") {
+    return {
+      command: process.env.COMSPEC || "cmd.exe",
+      args: ["/d", "/s", "/c", command],
+    };
+  }
+  return {
+    command: process.env.SHELL || "/bin/sh",
+    args: ["-lc", command],
+  };
 }
 
 function normalizeRoute(route) {
@@ -1530,6 +1662,82 @@ function runCommandAsync(command, args, timeoutMs = getProbeCommandTimeoutMs()) 
   });
 }
 
+function runCommandDetailedAsync(command, args, options = {}) {
+  const timeoutMs = Math.max(1000, Number(options.timeoutMs || getProbeCommandTimeoutMs()));
+  const cwd = String(options.cwd || "").trim() || undefined;
+  const env = options.env && typeof options.env === "object" ? options.env : process.env;
+  return new Promise((resolve, reject) => {
+    let child;
+    try {
+      child = spawn(command, args, {
+        cwd,
+        env,
+        windowsHide: true,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (error) {
+      reject(error instanceof Error ? error : new Error(String(error || "command error")));
+      return;
+    }
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+    let forceTimer = null;
+
+    const finish = (error, payload) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      if (forceTimer) clearTimeout(forceTimer);
+      if (error) {
+        reject(error);
+      } else {
+        resolve(payload);
+      }
+    };
+
+    child.stdout?.on("data", (chunk) => {
+      stdout += String(chunk || "");
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += String(chunk || "");
+    });
+
+    child.on("error", (error) => {
+      finish(error instanceof Error ? error : new Error(String(error || "command error")));
+    });
+
+    child.on("close", (code) => {
+      const exitCode = Number.isFinite(Number(code)) ? Number(code) : null;
+      finish(null, {
+        exitCode,
+        stdout: String(stdout || "").trim(),
+        stderr: String(stderr || "").trim(),
+        timedOut,
+      });
+    });
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        killProcTree(child);
+      } catch {
+        // ignore timeout kill failures
+      }
+      forceTimer = setTimeout(() => {
+        finish(null, {
+          exitCode: null,
+          stdout: String(stdout || "").trim(),
+          stderr: String(stderr || "").trim(),
+          timedOut: true,
+        });
+      }, 1200);
+    }, timeoutMs);
+  });
+}
+
 function runPowerShellScriptAsync(script, timeoutMs = getProbeCommandTimeoutMs()) {
   const wrapped = `$ErrorActionPreference='Stop'; [Console]::OutputEncoding=[System.Text.Encoding]::UTF8; $OutputEncoding=[Console]::OutputEncoding; ${String(script || "")}`;
   return runCommandAsync(
@@ -1537,6 +1745,50 @@ function runPowerShellScriptAsync(script, timeoutMs = getProbeCommandTimeoutMs()
     ["-NoProfile", "-Command", wrapped],
     timeoutMs
   );
+}
+
+async function executeLocalCommand(payload = {}) {
+  if (!PET_PLUGIN_API_EXECUTE_ENABLED) {
+    throw createPluginHttpError("execute_disabled", 403);
+  }
+  const command = String(payload?.command || "").trim();
+  const cwd = resolveExecuteWorkingDirectory(payload?.cwd);
+  const timeoutMs = normalizeExecuteTimeoutMs(payload?.timeout_ms);
+  const launch = buildExecuteLaunch(command);
+  const result = await runCommandDetailedAsync(
+    launch.command,
+    launch.args,
+    {
+      cwd,
+      timeoutMs,
+      env: {
+        ...process.env,
+        PYTHONUTF8: process.env.PYTHONUTF8 || "1",
+        PYTHONIOENCODING: process.env.PYTHONIOENCODING || "utf-8",
+        TERM: process.env.TERM || "dumb",
+        CI: process.env.CI || "1",
+      },
+    }
+  );
+  const exitCode = result.exitCode;
+  const stdout = truncateExecuteOutput(result.stdout);
+  const stderr = truncateExecuteOutput(result.stderr);
+  const timedOut = Boolean(result.timedOut);
+  const summary = timedOut
+    ? `command timed out after ${timeoutMs}ms`
+    : exitCode === 0
+      ? "command succeeded with exit code 0"
+      : `command failed with exit code ${exitCode == null ? "unknown" : exitCode}`;
+
+  return {
+    command,
+    cwd,
+    exit_code: exitCode,
+    stdout,
+    stderr,
+    timed_out: timedOut,
+    summary,
+  };
 }
 
 async function collectWindowsProcessNamesAsync() {
@@ -2735,6 +2987,11 @@ async function startBackend() {
     ...process.env,
     PYTHONUTF8: "1",
     PYTHONIOENCODING: "utf-8",
+    AELIN_DESKTOP_PLUGIN_EXECUTE_ENABLED: process.env.AELIN_DESKTOP_PLUGIN_EXECUTE_ENABLED || "1",
+    AELIN_DESKTOP_PLUGIN_EXECUTE_TIMEOUT_SECONDS:
+      process.env.AELIN_DESKTOP_PLUGIN_EXECUTE_TIMEOUT_SECONDS || String(Math.max(5, Math.round(getProbeCommandTimeoutMs() / 1000))),
+    AELIN_DESKTOP_PLUGIN_EXECUTE_MAX_OUTPUT_CHARS:
+      process.env.AELIN_DESKTOP_PLUGIN_EXECUTE_MAX_OUTPUT_CHARS || String(PET_PLUGIN_API_EXECUTE_MAX_OUTPUT_CHARS),
     AELIN_DATABASE_URL: sqliteUrl(dbFile),
     AELIN_MEDIA_DIR: mediaDir,
     AELIN_CORS_ORIGINS: [


### PR DESCRIPTION
## Summary
- add a DeepAgents `execute` tool that routes short non-interactive commands through the desktop plugin
- expose a guarded desktop plugin execute endpoint with cwd allowlisting, timeout clamping, and output truncation
- register the tool only when desktop execution is enabled, update tool policy/capability reporting, and add backend coverage

## Validation
- `cd backend && pytest -q`
- `node --check desktop/src/aelin_desktop_runtime.cjs`
- real desktop smoke: started desktop dev runtime on isolated ports and verified `/api/v1/aelin/remote-control/execute` returned command output from `execute`
